### PR TITLE
Fix for ReplaceText findPattern overload when using no matchFormatting

### DIFF
--- a/Xceed.Words.NET/Src/Paragraph.cs
+++ b/Xceed.Words.NET/Src/Paragraph.cs
@@ -3468,14 +3468,14 @@ namespace Xceed.Words.NET
 
             processed += run.Value.Length;
           }
+        }
 
-          // Replace text when formatting matches.
-          if( formattingMatch )
-          {
+        // Replace text when formatting matches.
+        if( formattingMatch )
+        {
             var newValue = regexMatchHandler.Invoke( match.Groups[ 1 ].Value );
             this.InsertText( match.Index + match.Value.Length, newValue, trackChanges, newFormatting );
             this.RemoveText( match.Index, match.Value.Length, trackChanges );
-          }
         }
       }
     }


### PR DESCRIPTION
We have used DocX as described in your ParagraphSample.TextActions and run into the issue that not all occurrences of the findPattern are getting replaced. This PR fixes this probably unintended `if( formattingMatch )` placement.

