### PR TITLE
Fix format matching is always required

### DIFF
--- a/Xceed.Words.NET/Src/Paragraph.cs
+++ b/Xceed.Words.NET/Src/Paragraph.cs
@@ -3468,14 +3468,14 @@ namespace Xceed.Words.NET
 
             processed += run.Value.Length;
           }
+        }
 
-          // Replace text when formatting matches.
-          if( formattingMatch )
-          {
-            var newValue = regexMatchHandler.Invoke( match.Groups[ 1 ].Value );
-            this.InsertText( match.Index + match.Value.Length, newValue, trackChanges, newFormatting );
-            this.RemoveText( match.Index, match.Value.Length, trackChanges );
-          }
+        // Replace text when formatting matches.
+        if ( formattingMatch )
+        {
+          var newValue = regexMatchHandler.Invoke( match.Groups[ 1 ].Value );
+          this.InsertText( match.Index + match.Value.Length, newValue, trackChanges, newFormatting );
+          this.RemoveText( match.Index, match.Value.Length, trackChanges );
         }
       }
     }


### PR DESCRIPTION
When the parameter matchFormatting is set to null, it will never do text substitution because the if condition 

> if( matchFormatting != null )

 wraps the InsertText and RemoveText method call. 

My change will move the text substitution logic out of the if condition, so it will be evaluated and executed properly. 

Actually, the ReplaceText method before the one I changed has correct if logic.