### PR TITLE
Bugfix: Look for the paragraph number properties in the style as well

### DIFF
--- a/Xceed.Words.NET/Src/Container.cs
+++ b/Xceed.Words.NET/Src/Container.cs
@@ -477,7 +477,7 @@ namespace Xceed.Words.NET
       #region Styles
       XDocument style_document;
 
-      if( p._styles.Count() > 0 )
+      if( p.Style != null )
       {
         var style_package_uri = new Uri( "/word/styles.xml", UriKind.Relative );
         if( !Document._package.PartExists( style_package_uri ) )
@@ -506,14 +506,10 @@ namespace Xceed.Words.NET
                     where a != null
                     select a.Value;
 
-          foreach( XElement style in p._styles )
+          // If styles_element does not contain this element, then add it.
+          if (!ids.Contains(p.Style.Attribute(XName.Get("styleId", DocX.w.NamespaceName)).Value))
           {
-            // If styles_element does not contain this element, then add it.
-
-            if( !ids.Contains( style.Attribute( XName.Get( "styleId", DocX.w.NamespaceName ) ).Value ) )
-            {
-              styles_element.Add( style );
-            }
+            styles_element.Add(p.Style);
           }
         }
 

--- a/Xceed.Words.NET/Src/Paragraph.cs
+++ b/Xceed.Words.NET/Src/Paragraph.cs
@@ -19,6 +19,7 @@ using System.Linq;
 using System.Xml.Linq;
 using System.Text.RegularExpressions;
 using System.Security.Principal;
+using System.IO;
 using System.IO.Packaging;
 using System.Drawing;
 using System.Globalization;
@@ -36,7 +37,7 @@ namespace Xceed.Words.NET
     // The Append family of functions use this List to apply style.
     internal List<XElement> _runs;
     internal int _startIndex, _endIndex;
-    internal List<XElement> _styles = new List<XElement>();
+    internal XElement _style;
 
     internal const float DefaultLineSpacing = 1.1f * 20.0f;
 
@@ -817,6 +818,13 @@ namespace Xceed.Words.NET
       }
     }
 
+    public XElement Style
+    {
+      get
+      {
+        return _style;
+      }
+    }
 
     #endregion
 
@@ -831,37 +839,35 @@ namespace Xceed.Words.NET
 
       RebuildDocProperties();
 
-      //// Check if this Paragraph references any pStyle elements.
-      //var stylesElements = xml.Descendants( XName.Get( "pStyle", DocX.w.NamespaceName ) );
+      // Check if this Paragraph references a pStyle element.
+      var styleElement = xml.Descendants( XName.Get( "pStyle", DocX.w.NamespaceName ) ).FirstOrDefault();
 
-      //// If one or more pStyles are referenced.
-      //if( stylesElements.Count() > 0 )
-      //{
-      //  Uri style_package_uri = new Uri( "/word/styles.xml", UriKind.Relative );
-      //  PackagePart styles_document = document.package.GetPart( style_package_uri );
+      // If a pStyle is referenced.
+      if( styleElement != null )
+      {
+        string styleElementID = styleElement.Attribute( XName.Get( "val" , DocX.w.NamespaceName ) ).Value;
 
-      //  using( TextReader tr = new StreamReader( styles_document.GetStream() ) )
-      //  {
-      //    XDocument style_document = XDocument.Load( tr );
-      //    XElement styles_element = style_document.Element( XName.Get( "styles", DocX.w.NamespaceName ) );
+        Uri style_package_uri = new Uri( "/word/styles.xml", UriKind.Relative );
+        PackagePart styles_document = document._package.GetPart( style_package_uri );
 
-      //    var styles_element_ids = stylesElements.Select( e => e.Attribute( XName.Get( "val", DocX.w.NamespaceName ) ).Value );
+        using( TextReader tr = new StreamReader( styles_document.GetStream() ) )
+        {
+          XDocument style_document = XDocument.Load( tr );
+          XElement styles_element = style_document.Element( XName.Get( "styles", DocX.w.NamespaceName ) );
 
-      //    //foreach(string id in styles_element_ids)
-      //    //{
-      //    //    var style = 
-      //    //    (
-      //    //        from d in styles_element.Descendants()
-      //    //        let styleId = d.Attribute(XName.Get("styleId", DocX.w.NamespaceName))
-      //    //        let type = d.Attribute(XName.Get("type", DocX.w.NamespaceName))
-      //    //        where type != null && type.Value == "paragraph" && styleId != null && styleId.Value == id
-      //    //        select d
-      //    //    ).First();
-
-      //    //    styles.Add(style);
-      //    //} 
-      //  }
-      //}
+          foreach ( XElement style in styles_element.Descendants() )
+          {
+            XAttribute styleId = style.Attribute( XName.Get( "styleId", DocX.w.NamespaceName ) );
+            XAttribute type = style.Attribute( XName.Get( "type", DocX.w.NamespaceName ) );
+            if (type != null && type.Value == "paragraph" &&
+                styleId != null && styleId.Value == styleElementID)
+            {
+              _style = style;
+              break;
+            }
+          }
+        }
+      }
 
       _runs = Xml.Elements( XName.Get( "r", DocX.w.NamespaceName ) ).ToList();
     }

--- a/Xceed.Words.NET/Src/Paragraph.cs
+++ b/Xceed.Words.NET/Src/Paragraph.cs
@@ -4761,6 +4761,10 @@ namespace Xceed.Words.NET
     private XElement GetParagraphNumberProperties()
     {
       var numPrNode = Xml.Descendants().FirstOrDefault( el => el.Name.LocalName == "numPr" );
+      if (numPrNode == null && _style != null)
+      {
+        numPrNode = _style.Descendants().FirstOrDefault( el => el.Name.LocalName == "numPr" );
+      }
       return numPrNode;
     }
 


### PR DESCRIPTION
Currently Paragraph.ParagraphNumberProperties will return null and IsListItem will incorrectly return false when the numbering properties (numPr) are part of the style, this pull request fixes this issue.