### PR TITLE
Bugfix: correctly support color being set to "auto"

### DIFF
--- a/Xceed.Words.NET/Src/Formatting.cs
+++ b/Xceed.Words.NET/Src/Formatting.cs
@@ -784,7 +784,7 @@ namespace Xceed.Words.NET
               var color = option.GetAttribute( XName.Get( "color", DocX.w.NamespaceName ) );
               if( !string.IsNullOrEmpty( color ) )
               {
-                formatting.UnderlineColor = System.Drawing.ColorTranslator.FromHtml( string.Format( "#{0}", color ) );
+                formatting.UnderlineColor = ( color == "auto") ? Color.Black : System.Drawing.ColorTranslator.FromHtml( string.Format( "#{0}", color ) );
               }
             }
             catch( Exception )
@@ -806,7 +806,7 @@ namespace Xceed.Words.NET
             var fill = option.GetAttribute( XName.Get( "fill", DocX.w.NamespaceName ) );
             if( !string.IsNullOrEmpty( fill ) )
             {
-              formatting.Shading = System.Drawing.ColorTranslator.FromHtml( string.Format( "#{0}", fill ) );
+              formatting.Shading = ( fill == "auto") ? Color.White : System.Drawing.ColorTranslator.FromHtml( string.Format( "#{0}", fill ) );
             }
             break;
           case "rStyle":

--- a/Xceed.Words.NET/Src/Table.cs
+++ b/Xceed.Words.NET/Src/Table.cs
@@ -2194,7 +2194,7 @@ namespace Xceed.Words.NET
 
       // The color attribute is used for the border color
       var color = tblBorderType.Attribute( XName.Get( "color", DocX.w.NamespaceName ) );
-      if( color == null )
+      if( color == null || color.Value == "auto" )
       {
         // uses default border style
       }
@@ -2931,7 +2931,7 @@ namespace Xceed.Words.NET
         XAttribute fill = shd?.Attribute( XName.Get( "fill", DocX.w.NamespaceName ) );
 
         // If fill is null, this cell contains no Color information.
-        if( fill == null )
+        if( fill == null || fill.Value == "auto" )
           return Color.White;
 
         return ColorTranslator.FromHtml( string.Format( "#{0}", fill.Value ) );
@@ -3512,7 +3512,7 @@ namespace Xceed.Words.NET
         XElement tcPr = Xml.Element( XName.Get( "tcPr", DocX.w.NamespaceName ) );
         XElement shd = tcPr?.Element( XName.Get( "shd", DocX.w.NamespaceName ) );
         XAttribute fill = shd?.Attribute( XName.Get( "fill", DocX.w.NamespaceName ) );
-        if( fill == null )
+        if( fill == null || fill.Value == "auto" )
           return Color.Empty;
 
         int argb = Int32.Parse( fill.Value.Replace( "#", "" ), NumberStyles.HexNumber );
@@ -3916,7 +3916,7 @@ namespace Xceed.Words.NET
 
       // The color attribute is used for the border color
       XAttribute color = tcBorderType.Attribute( XName.Get( "color", DocX.w.NamespaceName ) );
-      if( color == null )
+      if( color == null || color.Value == "auto" )
       {
         // uses default border style
       }


### PR DESCRIPTION
This solved the "#auto is not a valid value for Int32." Exception (and others) that I got with some documents.