### PR TITLE
Bugfix: Alignment setter assumes default left-alignment

### DIFF
--- a/Xceed.Words.NET/Src/Paragraph.cs
+++ b/Xceed.Words.NET/Src/Paragraph.cs
@@ -595,19 +595,10 @@ namespace Xceed.Words.NET
         XElement pPr = GetOrCreate_pPr();
         XElement jc = pPr.Element( XName.Get( "jc", DocX.w.NamespaceName ) );
 
-        if( alignment != Xceed.Words.NET.Alignment.left )
-        {
-          if( jc == null )
-            pPr.Add( new XElement( XName.Get( "jc", DocX.w.NamespaceName ), new XAttribute( XName.Get( "val", DocX.w.NamespaceName ), alignment.ToString() ) ) );
-          else
-            jc.Attribute( XName.Get( "val", DocX.w.NamespaceName ) ).Value = alignment.ToString();
-        }
-
+        if( jc == null )
+          pPr.Add( new XElement( XName.Get( "jc", DocX.w.NamespaceName ), new XAttribute( XName.Get( "val", DocX.w.NamespaceName ), alignment.ToString() ) ) );
         else
-        {
-          if( jc != null )
-            jc.Remove();
-        }
+          jc.Attribute( XName.Get( "val", DocX.w.NamespaceName ) ).Value = alignment.ToString();
       }
     }
 


### PR DESCRIPTION
The Paragraph.Alignment setter assumes that the default alignment of documents is left-aligned. As part of this assumption, it ignores attempts to align paragraphs to the left by removing any alignment markup. However, this does not work when modifying documents where the default style specifies a different alignment. For example, if the default style is Justify (also known as Alignment.both), trying to Alignment to Alignment.left will result in no markup causing the paragraph's alignment to remain Justify. This fix assumes that the user wants to force alignment markup to what they are specifying and does not assume a default alignment.