### PR TITLE
Ability to preserve formatting for CustomProperty value.

### DIFF
--- a/Xceed.Document.NET/Src/Document.cs
+++ b/Xceed.Document.NET/Src/Document.cs
@@ -2079,7 +2079,7 @@ namespace Xceed.Document.NET
     /// </example>
     /// <seealso cref="CustomProperty"/>
     /// <seealso cref="CustomProperties"/>
-    public void AddCustomProperty( CustomProperty cp )
+    public void AddCustomProperty( CustomProperty cp, bool withFormatting = false)
     {
       // If this document does not contain a customFilePropertyPart create one.
       if( !_package.PartExists( new Uri( "/docProps/custom.xml", UriKind.Relative ) ) )
@@ -2142,7 +2142,7 @@ namespace Xceed.Document.NET
       }
 
       // Refresh all fields in this document which display this custom property.
-      Document.UpdateCustomPropertyValue( this, cp.Name, ( cp.Value ?? "" ).ToString() );
+      Document.UpdateCustomPropertyValue( this, cp.Name, ( cp.Value ?? "" ).ToString(), withFormatting );
     }
 
     public override Paragraph InsertParagraph()
@@ -3199,14 +3199,15 @@ namespace Xceed.Document.NET
       Document.PopulateDocument( document, document._package );
     }
 
-    /// <summary>
-    /// Update the custom properties inside the document
-    /// </summary>
-    /// <param name="document">The Document document</param>
-    /// <param name="customPropertyName">The property used inside the document</param>
-    /// <param name="customPropertyValue">The new value for the property</param>
-    /// <remarks>Different version of Word create different Document XML.</remarks>
-    internal static void UpdateCustomPropertyValue( Document document, string customPropertyName, string customPropertyValue )
+        /// <summary>
+        /// Update the custom properties inside the document
+        /// </summary>
+        /// <param name="document">The Document document</param>
+        /// <param name="customPropertyName">The property used inside the document</param>
+        /// <param name="customPropertyValue">The new value for the property</param>
+        /// <param name="withFormatting">Use formatting for the new value</param>
+        /// <remarks>Different version of Word create different Document XML.</remarks>
+        internal static void UpdateCustomPropertyValue( Document document, string customPropertyName, string customPropertyValue, bool withFormatting = false )
     {
       // A list of documents, which will contain, The Main Document and if they exist: header1, header2, header3, footer1, footer2, footer3.
       var documents = new List<XElement> { document._mainDoc.Root };
@@ -3276,7 +3277,14 @@ namespace Xceed.Document.NET
                 {
                   if( !found )
                   {
-                    match.First().Value = customPropertyValue;
+                    var first = match.First();
+                    if (withFormatting)
+                    {
+                      first.Value = "\n";
+                      first.Add(HelperFunctions.FormatInput(customPropertyValue, null));
+                    }
+                    else
+                      first.Value = customPropertyValue;
                     found = true;
                   }
                   else

--- a/Xceed.Words.NET.Examples/Samples/Document/DocumentSample.cs
+++ b/Xceed.Words.NET.Examples/Samples/Document/DocumentSample.cs
@@ -126,6 +126,7 @@ namespace Xceed.Words.NET.Examples
         document.AddCustomProperty( new CustomProperty( "Product", "Xceed Words for .NET" ) );
         document.AddCustomProperty( new CustomProperty( "Address", "3141 Taschereau, Greenfield Park" ) );
         document.AddCustomProperty( new CustomProperty( "Date", DateTime.Now ) );
+        document.AddCustomProperty( new CustomProperty("Formatted", $"First Line{Environment.NewLine}Second Line{Environment.NewLine}Third Line"), true );
 
         // Add a paragraph displaying the number of custom properties.
         var p = document.InsertParagraph( "This document contains " ).Append( document.CustomProperties.Count.ToString() ).Append(" Custom Properties :");


### PR DESCRIPTION
**Issue:**
Formatting in CustomProperty.Value wasn't preserved, because it's added as string value to xElement.

**PR:**
Parameter **withFormatting** to **Xceed.Document.NET.Document.UpdateCustomPropertyValue** method. When true, CustomProperty.Value is formatted using **HelperFunctions.FormatInput**.