### PR TITLE
Fix computation of start index (fixes #414)

### DIFF
--- a/Xceed.Document.NET/Src/Paragraph.cs
+++ b/Xceed.Document.NET/Src/Paragraph.cs
@@ -2037,6 +2037,7 @@ namespace Xceed.Document.NET
                 reCalculateIds = true;
               }
               // Split this run at the point you want to insert
+              index += run.StartIndex;
               var splitRun = Run.SplitRun( run, index );
 
               // Replace the origional run
@@ -3611,6 +3612,7 @@ namespace Xceed.Document.NET
             {
               if( Paragraph.GetElementTextLength( run.Xml ) > 0 )
               {
+                index += run.StartIndex;
                 var splitRunBefore = Run.SplitRun( run, index, EditType.del );
                 var min = Math.Min( index + ( count - processed ), run.EndIndex );
                 var splitRunAfter = Run.SplitRun( run, min, EditType.del );


### PR DESCRIPTION
Further analysis of #414 showed that whenever the string to be replaced was not contained in the first run of the paragraph, the replacement was completely off.

This is due to the fact that the `StartIndex` of the run is not correctly taken into account when `InsertText` or `RemoveText` is executed.

This PR fixes this.