### PR TITLE
Ignore Fallback and drawing in GetFirstRunEffectedByEditRecursive (fixes #414)

### DIFF
--- a/Xceed.Document.NET/Src/Paragraph.cs
+++ b/Xceed.Document.NET/Src/Paragraph.cs
@@ -5079,7 +5079,11 @@ namespace Xceed.Document.NET
         return;
       }
 
-      if( Xml.HasElements )
+      // Ignore Fallback and drawing to be symmetric with HelperFunctions.GetTextRecursive.
+      var fallbackValue = Xml.Name.Equals(XName.Get("Fallback", Document.mc.NamespaceName));
+      var drawingValue = Xml.Name.Equals(XName.Get("drawing", Document.w.NamespaceName));
+
+      if( Xml.HasElements && !fallbackValue && !drawingValue )
       {
         foreach( XElement e in Xml.Elements() )
         {


### PR DESCRIPTION
`HelperFunctions.GetTextRecursive` ignores `Fallback` and `drawing` elements when determining the text value of a run. However, `GetFirstRunEffectedByEditRecursive` did not ignore these elements, resulting in incompatible text indices in presence of such elements (e.g. when text fields are used - as shown in #414).

This PR fixes this issue by ignoring `Fallback` and `drawing` elements also in `GetFirstRunEffectedByEditRecursive`.